### PR TITLE
BL-25810 ignoring internal links in spell checker

### DIFF
--- a/es5/markdown-parser.js
+++ b/es5/markdown-parser.js
@@ -17,10 +17,9 @@ exports.default = function (src) {
   if (jekyllFrontMatter) {
     tracker.replaceAll(jekyllFrontMatter, " ");
   }
-
   tracker.removeAll(/\[.*?\]/); // remove content in square bracket []
  // tracker.removeAll(/[a-zA-Z]+(_[a-zA-Z]*)+/);  remove snake_case words
-
+  tracker.removeAll(/\(#.+?\)/) // remove internal links
   tracker.removeAll(/```[\w\W]*?```/);
   tracker.removeAll(/~~~[\w\W]*?~~~/);
   tracker.removeAll(/``[\w\W]*?``/);

--- a/es6/markdown-parser.js
+++ b/es6/markdown-parser.js
@@ -18,7 +18,7 @@ export default function(src) {
 
   tracker.removeAll(/\[.*?\]/); // remove content in square bracket []
   //tracker.removeAll(/[a-zA-Z]+(_[a-zA-Z]*)+/);  remove snake_case words
-
+  tracker.removeAll(/\(#.+?\)/) // remove internal links
   tracker.removeAll(/```[\w\W]*?```/);
   tracker.removeAll(/~~~[\w\W]*?~~~/);
   tracker.removeAll(/``[\w\W]*?``/);


### PR DESCRIPTION
Jira link: https://bankofloyal.atlassian.net/browse/BL-25810
`(#Internal-links)` -> This pattern should be ignored by `mdspell`.

Ex.
![image](https://user-images.githubusercontent.com/66009833/97430964-a366f600-193f-11eb-8488-62594c944e91.png)
